### PR TITLE
arm64: fix dtb folder

### DIFF
--- a/arch/arm64/boot/Makefile
+++ b/arch/arm64/boot/Makefile
@@ -24,7 +24,7 @@ DTB_LIST := $(addsuffix .dtb,$(DTB_NAMES))
 else
 DTB_LIST := $(dtb-y)
 endif
-DTB_OBJS := $(addprefix $(obj)/dts/,$(DTB_LIST))
+DTB_OBJS := $(addprefix $(obj)/../../*/boot/dts/,$(DTB_LIST))
 
 $(obj)/Image: vmlinux FORCE
 	$(call if_changed,objcopy)


### PR DESCRIPTION
dtb files are created in arm/boot/dts for both 32bit and 64bit platforms.
this patch fixes the dtb path so that it can be appended to Image for 64bit Qualcom devices
